### PR TITLE
Document options.headers with more thorough examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ var opts = {
 	method: 'PUT',
 	host: 'johnsmith.s3.amazonaws.com',
 	path: '/photos/puppy.jpg',
-	headers: { ... },
+	headers: { 
+		'content-type': 'image/jpeg',
+		'date': 'Tue, 27 Mar 2007 21:15:45 +0000',
+		'content-md5': '...',
+		'x-amz-???': '...'
+	},
 	... // Other request options, ignored by AwsSign.
 };
 signer.sign(opts);


### PR DESCRIPTION
This documents the list of headers that `aws-sign` specifically sets.
Also, since the `content-type` header can also be specified elsewhere
in camelcase, it is helpful to let users know they need to specify
headers using the dashed notation.